### PR TITLE
fix: fix high-probability directory creation race condition error

### DIFF
--- a/train.py
+++ b/train.py
@@ -249,10 +249,8 @@ def train_fn(
     if positional_sampling_ratio is not None and positional_sampling_ratio < 1:
         model_desc += f"-d{positional_sampling_ratio}"
     # creates subfolders.
-    if not os.path.exists(f"./exps/{model_subfolder}"):
-        os.makedirs(f"./exps/{model_subfolder}")
-    if not os.path.exists(f"./ckpts/{model_subfolder}"):
-        os.makedirs(f"./ckpts/{model_subfolder}")
+    os.makedirs(f"./exps/{model_subfolder}", exist_ok=True)
+    os.makedirs(f"./ckpts/{model_subfolder}", exist_ok=True)
     log_dir = f"./exps/{model_desc}"
     if rank == 0:
         writer = SummaryWriter(log_dir=log_dir)


### PR DESCRIPTION
Fixed a high-probability directory creation race condition error during multi-process execution.

ERROR:
```bash
$ CUDA_VISIBLE_DEVICES="0,1,2,3" python3 train.py --gin_config_file=configs/ml-20m/hstu-sampled-softmax-n128-final.gin --master_port=12345
...

W0429 14:42:54.424259 140382137931584 torch/multiprocessing/spawn.py:145] Terminating process 583727 via signal SIGTERM
W0429 14:42:54.425160 140382137931584 torch/multiprocessing/spawn.py:145] Terminating process 583728 via signal SIGTERM
Traceback (most recent call last):
  File "/nas/src/adsinfra/generative-recommenders/train.py", line 482, in <module>
    app.run(main)
  File "/usr/local/lib/python3.9/dist-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "/usr/local/lib/python3.9/dist-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "/nas/src/adsinfra/generative-recommenders/train.py", line 475, in main
    mp.spawn(mp_train_fn,
  File "/usr/local/lib/python3.9/dist-packages/torch/multiprocessing/spawn.py", line 281, in spawn
    return start_processes(fn, args, nprocs, join, daemon, start_method="spawn")
  File "/usr/local/lib/python3.9/dist-packages/torch/multiprocessing/spawn.py", line 237, in start_processes
    while not context.join():
  File "/usr/local/lib/python3.9/dist-packages/torch/multiprocessing/spawn.py", line 188, in join
    raise ProcessRaisedException(msg, error_index, failed_process.pid)
torch.multiprocessing.spawn.ProcessRaisedException:

-- Process 3 terminated with the following error:
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/torch/multiprocessing/spawn.py", line 75, in _wrap
    fn(i, *args)
  File "/nas/src/adsinfra/generative-recommenders/train.py", line 468, in mp_train_fn
    train_fn(rank, world_size, master_port)
  File "/usr/local/lib/python3.9/dist-packages/gin/config.py", line 1605, in gin_wrapper
    utils.augment_exception_message_and_reraise(e, err_str)
  File "/usr/local/lib/python3.9/dist-packages/gin/utils.py", line 41, in augment_exception_message_and_reraise
    raise proxy.with_traceback(exception.__traceback__) from None
  File "/usr/local/lib/python3.9/dist-packages/gin/config.py", line 1582, in gin_wrapper
    return fn(*new_args, **new_kwargs)
  File "/nas/src/adsinfra/generative-recommenders/train.py", line 253, in train_fn
    os.makedirs(f"./exps/{model_subfolder}")
  File "/usr/lib/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: './exps/ml-20m-l200'
  In call to configurable 'train_fn' (<function train_fn at 0x7f5e42df3160>)
```