### PR TITLE
Triton autotuner also takes pre_hook/post_hook as args, changing the arg order.

### DIFF
--- a/generative_recommenders/ops/triton/utils.py
+++ b/generative_recommenders/ops/triton/utils.py
@@ -97,9 +97,11 @@ def triton_autotune(
             key,
             reset_to_zero,
             restore_value,
-            prune_configs_by,
-            warmup,
-            rep,
+            pre_hook=None,
+            post_hook=None,
+            prune_configs_by=prune_configs_by,
+            warmup=warmup,
+            rep=rep,
         )
 
     return decorator


### PR DESCRIPTION
Differential Revision: D65699449


