### PR TITLE
Fix type-safety of `torch.nn.Module` instances

### DIFF
--- a/generative_recommenders/modeling/sequential/autoregressive_losses.py
+++ b/generative_recommenders/modeling/sequential/autoregressive_losses.py
@@ -170,13 +170,18 @@ class InBatchNegativesSampler(NegativesSampler):
                 valid_ids.numel(), dtype=torch.int64, device=device
             )
             unique_embeddings = embeddings[presences][unique_embedding_offsets, :]
+            # pyre-fixme[16]: `InBatchNegativesSampler` has no attribute
+            #  `_cached_embeddings`.
             self._cached_embeddings = self._maybe_l2_norm(unique_embeddings)
+            # pyre-fixme[16]: `InBatchNegativesSampler` has no attribute `_cached_ids`.
             self._cached_ids = unique_ids
         else:
             self._cached_embeddings = self._maybe_l2_norm(embeddings[presences])
             self._cached_ids = ids[presences]
 
     def get_all_ids_and_embeddings(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        # pyre-fixme[7]: Expected `Tuple[Tensor, Tensor]` but got
+        #  `Tuple[Union[Tensor, Module], Union[Tensor, Module]]`.
         return self._cached_ids, self._cached_embeddings
 
     def forward(
@@ -197,7 +202,9 @@ class InBatchNegativesSampler(NegativesSampler):
             device=positive_ids.device,
         )
         return (
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             self._cached_ids[sampled_offsets],
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             self._cached_embeddings[sampled_offsets],
         )
 
@@ -287,6 +294,7 @@ class BCELoss(AutoregressiveLoss):
         )
 
         positive_logits = (
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             self._model.interaction(
                 input_embeddings=output_embeddings,  # [B, D] = [N', D]
                 target_ids=supervision_ids.unsqueeze(1),  # [N', 1]
@@ -298,6 +306,7 @@ class BCELoss(AutoregressiveLoss):
         )  # [N']
 
         sampled_negatives_logits = (
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             self._model.interaction(
                 input_embeddings=output_embeddings,  # [N', D]
                 target_ids=sampled_ids,  # [N', 1]
@@ -403,6 +412,7 @@ class BCELossWithRatings(AutoregressiveLoss):
         assert supervision_ids.size() == supervision_weights.size()
 
         target_logits = (
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             self._model.interaction(
                 input_embeddings=output_embeddings,  # [B, D] = [N', D]
                 target_ids=supervision_ids.unsqueeze(1),  # [N', 1]
@@ -516,6 +526,7 @@ class SampledSoftmaxLoss(AutoregressiveLoss):
             supervision_embeddings
         )
         positive_logits = (
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             self._model.interaction(
                 input_embeddings=output_embeddings,  # [B, D] = [N', D]
                 target_ids=supervision_ids.unsqueeze(1),  # [N', 1]
@@ -525,6 +536,7 @@ class SampledSoftmaxLoss(AutoregressiveLoss):
             )
             / self._softmax_temperature
         )  # [0]
+        # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
         sampled_negatives_logits = self._model.interaction(
             input_embeddings=output_embeddings,  # [N', D]
             target_ids=sampled_ids,  # [N', R]

--- a/generative_recommenders/modeling/similarity/mol.py
+++ b/generative_recommenders/modeling/similarity/mol.py
@@ -420,13 +420,24 @@ class MoLSimilarity(torch.nn.Module):
     def _frequency_estimator_old(self, ids: torch.Tensor) -> torch.Tensor:
         ids_shape = ids.size()
         ids = ids.reshape(-1)
+        # pyre-fixme[58]: `-` is not supported for operand types `int` and
+        #  `Union[Tensor, Module]`.
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         temp = (1 - self._lnx_estimator_alpha) * self._B[
             ids
+            # pyre-fixme[29]: `Union[(self: TensorBase, other: Union[bool, complex,
+            #  float, int, Tensor]) -> Tensor, Tensor, Module]` is not a function.
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         ] + self._lnx_estimator_alpha * (self._lnx_num_batches + 1 - self._A[ids])
         temp = torch.clamp(temp, max=self._lnx_estimator_b_cap)  # pyre-ignore [6]
         if self.train:
+            # pyre-fixme[16]: `MoLSimilarity` has no attribute `_lnx_num_batches`.
+            # pyre-fixme[29]: `Union[(self: TensorBase, other: Union[bool, complex,
+            #  float, int, Tensor]) -> Tensor, Tensor, Module]` is not a function.
             self._lnx_num_batches = self._lnx_num_batches + 1
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             self._B[ids] = temp
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             self._A[ids] = self._lnx_num_batches
         return torch.div(1.0, temp.reshape(ids_shape))
 
@@ -448,22 +459,36 @@ class MoLSimilarity(torch.nn.Module):
         )
         delta_batches = torch.zeros_like(ids, dtype=torch.float32)
         delta_batches[sorted_id_indices] = torch.gather(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             input=(most_recent_batches - self._A[sorted_unique_ids]).float()
             / sorted_unique_cnts.float(),
             dim=0,
             index=sorted_unique_inverses,
         )
 
+        # pyre-fixme[58]: `-` is not supported for operand types `int` and
+        #  `Union[Tensor, Module]`.
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         temp = (1 - self._lnx_estimator_alpha) * self._B[
             ids
+            # pyre-fixme[29]: `Union[(self: TensorBase, other: Union[bool, complex,
+            #  float, int, Tensor]) -> Tensor, Tensor, Module]` is not a function.
         ] + self._lnx_estimator_alpha * delta_batches
         temp = torch.clamp(temp, max=self._lnx_estimator_b_cap)  # pyre-ignore [6]
 
         if update:
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             self._B[ids] = temp
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             self._A[sorted_unique_ids] = most_recent_batches
+            # pyre-fixme[16]: `MoLSimilarity` has no attribute
+            #  `_lnx_estimator_num_elements`.
             self._lnx_estimator_num_elements = (
-                self._lnx_estimator_num_elements + ids.numel()
+                # pyre-fixme[29]: `Union[(self: TensorBase, other: Union[bool,
+                #  complex, float, int, Tensor]) -> Tensor, Tensor, Module]` is not a
+                #  function.
+                self._lnx_estimator_num_elements
+                + ids.numel()
             )
         return torch.div(1.0, temp.reshape(ids_shape))
 

--- a/generative_recommenders/trainer/train.py
+++ b/generative_recommenders/trainer/train.py
@@ -363,6 +363,8 @@ def train_fn(
                     embeddings=model.module.get_item_embeddings(in_batch_ids),
                 )
             else:
+                # pyre-fixme[16]: `InBatchNegativesSampler` has no attribute
+                #  `_item_emb`.
                 negatives_sampler._item_emb = model.module._embedding_module._item_emb
 
             ar_mask = supervision_ids[:, 1:] != 0


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/3387

X-link: https://github.com/facebookresearch/FBGEMM/pull/476

X-link: https://github.com/pytorch/torchrec/pull/2562

As laid out in https://github.com/pytorch/pytorch/issues/81462#issuecomment-1838731223 the change in https://github.com/pytorch/pytorch/pull/104321 was not necessary and largely destroys the type-safety of `torch.nn.Module` instances.

As far as I can see, the underlying issue of https://github.com/pytorch/pytorch/issues/81462 in `torch.nn.parallel.DistributedDataParallel` has been fixed in the meantime by actually typing `register_comm_hook` correctly.

The proper solution to issues like https://github.com/pytorch/pytorch/issues/81462 is to give the underlying field/method a proper type annotation, then there should be no need to go for a "type system disabling `__getattr__`".

(I'll probably be offline for a while, not able to react here...)

cc H-Huang awgu kwen2501 wanchaol fegin fduwjj wz337 wconstab d4l3k c-p-i-o voznesenskym penguinwu EikanWang jgong5 Guobing-Chen XiaobingSuper zhuhaozhe blzheng wenzhe-nrv jiayisunx ipiszy yf225 chenyang78 kadeng muchulee8 ColinPeppler amjames desertfire chauhang aakhundov avikchaudhuri gmagogsfm zhxchen17 tugsbayasgalan angelayi suo ydwu4 XilunWu rec mrshenli pritamdamania87 zhaojuanmao satgera rohan-varma gqchen aazzolini osalpekar jiayisuse tianyu-l kiukchung lucasllc

X-link: https://github.com/pytorch/pytorch/pull/115074

Reviewed By: malfet, aorenste, gineshidalgo99, larryliu0820

Differential Revision: D52890934

Pulled By: ezyang


