### PR TITLE
restore missing fbgemm_gpu import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Don't check in parsed data files
 tmp/
+ckpts/
+exps/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from typing import List, Optional
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # Hide excessive tensorflow debug messages
 import sys
 
+import fbgemm_gpu  # noqa: F401, E402
 import gin
 
 import torch


### PR DESCRIPTION
Fixes #134

Restore the accidentally removed fbgemm_gpu import statement which caused runtime errors.