### PR TITLE
restore missing fbgemm_gpu import

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from typing import List, Optional
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # Hide excessive tensorflow debug messages
 import sys
 
+import fbgemm_gpu  # noqa: F401, E402
 import gin
 
 import torch


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/generative-recommenders/issues/134

Restore the accidentally removed fbgemm_gpu import statement which caused runtime errors.