### PR TITLE
Fix AOTI autotune error "Failed to run autotuning code block: name '_launcher_s0' is not defined"

### DIFF
--- a/generative_recommenders/ops/triton/triton_jagged.py
+++ b/generative_recommenders/ops/triton/triton_jagged.py
@@ -264,7 +264,7 @@ class _JaggedDenseBmmFunction(torch.autograd.Function):
             seq_offsets=seq_offsets,
             Jagged=jagged,
             Dense=dense,
-            Bias=None,
+            Bias=0,
             Out=bmm_out,
             AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
             N=K,


### PR DESCRIPTION
Reviewed By: zhangruiskyline

Differential Revision: D73827636


