### PR TITLE
reduce DRAM usage in streaming model training

### DIFF
--- a/generative_recommenders/dlrm_v3/train/train_ranker.py
+++ b/generative_recommenders/dlrm_v3/train/train_ranker.py
@@ -75,7 +75,7 @@ def _main_func(
     gin.parse_config_file(gin_file)
 
     model, model_configs, embedding_table_configs = make_model()
-    model, optimizer = make_optimizer_and_shard(model=model, device=device)
+    model, optimizer = make_optimizer_and_shard(model=model, device=device, world_size=world_size)
     train_dataloader, test_dataloader = make_train_test_dataloaders(
         hstu_config=model_configs,
         embedding_table_configs=embedding_table_configs,


### PR DESCRIPTION
using a non-default topology configuration by specifying 160GB of HBM and 32 GB of DRAM can force the sharder to put the full embedding table on GPU's HBM 