### PR TITLE
add tuning parameter waves_per_eu to get perf back with async_copy turned on

### DIFF
--- a/generative_recommenders/ops/triton/triton_hstu_attention.py
+++ b/generative_recommenders/ops/triton/triton_hstu_attention.py
@@ -84,19 +84,20 @@ def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
                 for num_stages in [1, 2]:
                     for num_warps in [4, 8]:
                         for matrix_instr_nonkdim in [16, 32]:
-                            configs.append(
-                                triton.Config(
-                                    {
-                                        "BLOCK_M": BLOCK_M,
-                                        "BLOCK_N": BLOCK_N,
-                                        "matrix_instr_nonkdim": matrix_instr_nonkdim,
-                                        "waves_per_eu": 0,
-                                        "kpack": 2,
-                                    },
-                                    num_stages=num_stages,
-                                    num_warps=num_warps,
+                            for waves_per_eu in [0, 1, 2]:
+                                configs.append(
+                                    triton.Config(
+                                        {
+                                            "BLOCK_M": BLOCK_M,
+                                            "BLOCK_N": BLOCK_N,
+                                            "matrix_instr_nonkdim": matrix_instr_nonkdim,
+                                            "waves_per_eu": waves_per_eu,
+                                            "kpack": 2,
+                                        },
+                                        num_stages=num_stages,
+                                        num_warps=num_warps,
+                                    )
                                 )
-                            )
     else:
         configs = [
             triton.Config(


### PR DESCRIPTION
Triton AMD backend turned on async copy feature with `TRITON_HIP_USE_ASYNC_COPY=1` by default, and tritonbench saw perf regression for the hstu fwd kernel. With some investigation, we can get the perf back with the changes here. 

Now the perf is: 
- aync_copy on
```
                               x_val        hstu-latency    hstu-tflops
------------------------------------  ------------------  -------------
 (128, 4, 256, 128, 128, 1.0, 20, 0)  0.124761 (±10.20%)        68.8511
 (128, 4, 512, 128, 128, 1.0, 20, 0)   0.182281 (±1.62%)       188.499
(128, 4, 1024, 128, 128, 1.0, 20, 0)   0.545444 (±2.98%)       251.976
                             average  0.2841620047887166       169.775
```
- async_copy off
```
                               x_val        hstu-latency    hstu-tflops
------------------------------------  ------------------  -------------
 (128, 4, 256, 128, 128, 1.0, 20, 0)   0.130121 (±9.04%)         66.015
 (128, 4, 512, 128, 128, 1.0, 20, 0)   0.184242 (±1.37%)        186.492
(128, 4, 1024, 128, 128, 1.0, 20, 0)   0.558646 (±3.24%)        246.022
                             average  0.2910030037164688        166.176
```
so perf are close now. 