### PR TITLE
Add OSS fallback for libfb none_throws import in contextualize_mlps

### DIFF
--- a/generative_recommenders/modules/contextualize_mlps.py
+++ b/generative_recommenders/modules/contextualize_mlps.py
@@ -16,13 +16,22 @@
 
 # pyre-strict
 import abc
-from typing import Optional
+from typing import Optional, TypeVar
 
 import torch
 from generative_recommenders.common import HammerModule, init_mlp_weights_optional_bias
 from generative_recommenders.ops.jagged_tensors import jagged_dense_bmm_broadcast_add
 from generative_recommenders.ops.layer_norm import LayerNorm, SwishLayerNorm
-from libfb.py.pyre import none_throws
+
+try:
+    from libfb.py.pyre import none_throws
+except ImportError:
+    _T = TypeVar("_T")
+
+    def none_throws(optional: Optional[_T], message: str = "Unexpected `None`") -> _T:
+        if optional is None:
+            raise AssertionError(message)
+        return optional
 
 
 class ContextualizedMLP(HammerModule):


### PR DESCRIPTION
## Summary
`generative_recommenders/modules/contextualize_mlps.py` imports
`from libfb.py.pyre import none_throws`. `libfb` is Meta's internal monorepo
library and is not shipped in the OSS release, so this module fails at import
time for external users — even though `none_throws` is only used at a single
call site in `ParameterizedContextualizedMLP.forward`.

This wraps the import in `try/except ImportError` with a small inline fallback,
following the existing convention for internal-only imports in `common.py`
(`hammer.*`, `generative_recommenders.fb.*`).

## Test plan
- [x] `python -m py_compile generative_recommenders/modules/contextualize_mlps.py`
- [x] Verified the fallback returns the value for non-None input and raises `AssertionError` on `None`
- [ ] CI test suite